### PR TITLE
Remove metrics when ExternalSecret is deleted

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -76,7 +76,8 @@ async function main () {
     externalSecretEvents,
     logger,
     pollerFactory,
-    instanceId
+    instanceId,
+    metrics
   })
 
   const metricsServer = new MetricsServer({

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -9,12 +9,14 @@ class Daemon {
    * @param {Object} externalSecretEvents - Stream of external secret events.
    * @param {Object} logger - Logger for logging stuff.
    * @param {number} pollerIntervalMilliseconds - Interval time in milliseconds for polling secret properties.
+   * @param {Object} metrics - Metrics client.
    */
   constructor ({
     instanceId,
     externalSecretEvents,
     logger,
-    pollerFactory
+    pollerFactory,
+    metrics
   }) {
     this._instanceId = instanceId
     this._externalSecretEvents = externalSecretEvents
@@ -22,6 +24,7 @@ class Daemon {
     this._pollerFactory = pollerFactory
 
     this._pollers = {}
+    this._metrics = metrics
   }
 
   /**
@@ -79,6 +82,11 @@ class Daemon {
 
       switch (event.type) {
         case 'DELETED': {
+          this._metrics.removeMetricsForGivenES({
+            name: this._pollers[descriptor.id]._name,
+            namespace: this._pollers[descriptor.id]._namespace,
+            backend: this._pollers[descriptor.id]._spec.backendType
+          })
           this._removePoller(descriptor.id)
           break
         }

--- a/lib/metrics-server.js
+++ b/lib/metrics-server.js
@@ -17,9 +17,9 @@ class MetricsServer {
     this._registry = registry
 
     this._app = express()
-    this._app.get('/metrics', (req, res) => {
+    this._app.get('/metrics', async (req, res) => {
       res.set('Content-Type', Prometheus.register.contentType)
-      res.end(this._registry.metrics())
+      res.end(await this._registry.metrics())
     })
   }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -79,6 +79,49 @@ class Metrics {
       }, -1)
     }
   }
+
+  /**
+   * Remove the metrics of a given External Secret
+   * @param {String} name - the name of the externalSecret
+   * @param {String} namespace - the namespace of the externalSecret
+   * @param {String} backend - the backend used to fetch the externalSecret
+   */
+  removeMetricsForGivenES ({ name, namespace, backend }) {
+    this._syncCallsCount.remove({
+      name,
+      namespace,
+      backend,
+      status: 'success'
+    })
+    this._syncCalls.remove({
+      name,
+      namespace,
+      backend,
+      status: 'success'
+    })
+    this._syncCallsCount.remove({
+      name,
+      namespace,
+      backend,
+      status: 'error'
+    })
+    this._syncCalls.remove({
+      name,
+      namespace,
+      backend,
+      status: 'error'
+    })
+    this._lastSyncCallState.remove({
+      name,
+      namespace,
+      backend
+    })
+    this._lastState.remove({
+      name,
+      namespace,
+      backend
+    })
+  }
 }
 
 module.exports = Metrics

--- a/lib/metrics.test.js
+++ b/lib/metrics.test.js
@@ -20,15 +20,18 @@ describe('Metrics', () => {
     sinon.restore()
   })
 
-  it('should store metrics', async () => {
+  it('should store metrics and be able to remove them', async () => {
     metrics.observeSync({
       name: 'foo',
       namespace: 'example',
       backend: 'foo',
       status: 'success'
     })
-    expect(registry.metrics()).to.have.string('kubernetes_external_secrets_sync_calls_count{name="foo",namespace="example",backend="foo",status="success"} 1')
+    expect(await registry.metrics()).to.have.string('kubernetes_external_secrets_sync_calls_count{name="foo",namespace="example",backend="foo",status="success"} 1')
     // Deprecated metric.
-    expect(registry.metrics()).to.have.string('sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1')
+    expect(await registry.metrics()).to.have.string('sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1')
+
+    metrics.removeMetricsForGivenES({ name: 'foo', namespace: 'example', backend: 'foo' })
+    expect(await registry.metrics()).not.to.have.string('foo')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1583,9 +1583,9 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -6472,9 +6472,9 @@
       "dev": true
     },
     "prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz",
+      "integrity": "sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==",
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -7715,11 +7715,11 @@
       }
     },
     "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
       "requires": {
-        "bintrees": "1.0.1"
+        "bintrees": "1.0.2"
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "make-promises-safe": "^5.1.0",
     "node-vault": "^0.9.18",
     "pino": "^7.0.5",
-    "prom-client": "^12.0.0",
+    "prom-client": "^13.1.0",
     "proxy-agent": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We need to bump the prom-client to 13.1.0 to be able to remove metrics based on specific labels (cf https://github.com/siimon/prom-client/releases/tag/v13.1.0). With that new version, the registry.metrics() function becomes async that's why we have to alter some other parts of the code that has nothing to do with the initial topic of this PR.